### PR TITLE
Fix "Max number of dynamics shortcuts exceed" error & add a few features

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ RNAppShortcuts.updateShortcut({
 | longLabel | String | Long label for the shortcut. |
 | iconFolderName | String | Folder name of the shortcut's icon. For example, if the icon is in `./android/app/src/res/drawable` folder of your prject, you should use `'drawable'` here.|
 | iconName | String | Name of the icon, without extension name. |
-| oorder | Number | Position of the shortcut. The lower the number is (0 being the minimum value), the higher the icon will positionned. |
+| order | Number | Position of the shortcut. The lower the number is (0 being the minimum value), the higher the icon will positionned. |
 
 ### Remove App ShortCut
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If your app targets Android 7.1 (API level 25) or higher, you can define shortcu
 
 #### Android
 
-1. Open up `android/app/src/main/java/[...]/MainActivity.java`
+1. Open up `android/app/src/main/java/[...]/MainApplication.java`
   - Add `import com.rnas.RNAppShortcutsPackage;` to the imports at the top of the file
   - Add `new RNAppShortcutsPackage()` to the list returned by the `getPackages()` method
 2. Append the following lines to `android/settings.gradle`:
@@ -65,7 +65,8 @@ RNAppShortcuts.addShortcut({
   shortLabel: 'sample',
   longLabel: 'sample label',
   iconFolderName: 'drawable',
-  iconName: 'icon'
+  iconName: 'icon',
+  order: 0
 })
 ```
 
@@ -76,7 +77,8 @@ RNAppShortcuts.updateShortcut({
   shortLabel: 'updated',
   longLabel: 'updated label',
   iconFolderName: 'drawable',
-  iconName: 'icon'
+  iconName: 'icon',
+  order: 1
 })
 ```
 
@@ -89,6 +91,7 @@ RNAppShortcuts.updateShortcut({
 | longLabel | String | Long label for the shortcut. |
 | iconFolderName | String | Folder name of the shortcut's icon. For example, if the icon is in `./android/app/src/res/drawable` folder of your prject, you should use `'drawable'` here.|
 | iconName | String | Name of the icon, without extension name. |
+| oorder | Number | Position of the shortcut. The lower the number is (0 being the minimum value), the higher the icon will positionned. |
 
 ### Remove App ShortCut
 

--- a/android/src/main/java/com/rnas/RNAppShortcutsModule.java
+++ b/android/src/main/java/com/rnas/RNAppShortcutsModule.java
@@ -75,7 +75,7 @@ public class RNAppShortcutsModule extends ReactContextBaseJavaModule {
         if (Build.VERSION.SDK_INT < 25) return;
 
         if (isShortcutExist(id)) {
-            promise.resolve(true);
+            promise.resolve(null);
         } else {
             promise.reject(SHORTCUT_NOT_EXIST, "Not found this app shortcut");
         }


### PR DESCRIPTION
1. We we try to set more than 1 app shortcut, the app returns a red screen with the error : "Max number of dynamics shortcuts exceed".
<img alt="Screenshot of the Max number of dynamics shortcuts exceed error on Android" src="https://user-images.githubusercontent.com/8975443/30242522-37cbcc3c-9598-11e7-950a-41782c3fc316.png" width="300" />

This should not be the case anymore because we now make sure to not exceed the `shortcutManager.getMaxShortcutCountPerActivity` 👍

2. `ShortcutInfo.Builder` supports a `setRank` method, which could be pretty handy in some use cases. This PR adds the support of an `order` property inside the `RNAppShortcuts.addShortcut()` method. Thus, we are able to set the shortcuts order dynamically for instance, and do something like this:

```jsx
  import React from 'react'
  import RNAppShortcuts from 'react-native-app-shortcuts'
  ...

  export class Example extends React.Component {
    state = {
      appShortcuts: [
        {
          id: '/app/search',
          shortLabel: 'Search',
          longLabel: 'Search somthing',
          iconFolderName: 'drawable',
          iconName: 'search',
          order: 2, // Could also be based on some custom logic
        },
        {
          id: '/app/article/new',
          shortLabel: 'New',
          longLabel: 'New article',
          iconFolderName: 'drawable',
          iconName: 'pen',
          order: 0,
        },
        {
          id: '/app/notifications',
          shortLabel: 'Notifs',
          longLabel: 'Notifications',
          iconFolderName: 'drawable',
          iconName: 'clock',
          order: 1,
        },
      ]
    }

    // Will generate shortcuts: 'Search' -> 'Notifications' -> 'New Article' (from top to bottom)
    _createDynamicAppShortcuts = () =>
      this.state.data.map(shortcut => AppShortcuts.addShortcut(shortcut))

    render() {
      this._createDynamicAppShortcuts()
      return (
        ...
      )
    }
  }
```

3. From now on, `react-native-app-shortcuts` is also able to redirect the user to the `MainActivity` when the back button is pressed right after using a shortcut. The previous behaviour was leaving the app.